### PR TITLE
Add wiki text template parser for Abstract Wikipedia pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: pip install pyyaml pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -28,8 +28,46 @@ Abstract Wikipedia's API **does not support creating articles** (as of March 202
 | Script | Purpose |
 |--------|---------|
 | `create_rich_onepass.py` | Single-pass shrine creation via clipboard injection (current standard) |
+| `create_rich_threepass.py` | Three-fragment version with administrative territory |
+| `wikitext_parser.py` | Wiki text template parser: converts human-readable templates to clipboard JSON |
 | `runcreate.bat` | Quick launcher: creates 10 shrines in headed mode |
 | `archive/create_shrine_articles.py` | API-based approach (blocked by permissions, kept for reference) |
+
+## Wiki Text Templates
+
+The `wikitext_parser.py` module provides a MediaWiki-inspired template syntax for defining Abstract Wikipedia articles without hand-crafting nested Z-object JSON.
+
+**Template syntax:**
+```
+---
+title: Shinto Shrine
+variables:
+  deity: Q-item
+---
+{{Z26570 | $subject | Q845945 | Q17}}
+{{Z28016 | $deity | Q11591100 | $subject}}
+```
+
+Each `{{...}}` block becomes one clipboard fragment. The parser handles:
+- **Z-function calls** with positional or named arguments
+- **`$subject` / `$lang`** as implicit article entity/language references
+- **Q-items** automatically wrapped as Wikidata item references (Z6091)
+- **`$variables`** filled in at render time from the frontmatter or caller
+- **Auto-wrapping**: Z11-returning functions get Z29749, Z6-returning get Z27868
+
+**CLI usage:**
+```bash
+python wikitext_parser.py data/templates/shinto_shrine.wikitext deity=Q12345
+python wikitext_parser.py --list-functions
+```
+
+**Python usage:**
+```python
+from wikitext_parser import compile_template
+clipboard = compile_template(template_text, {"deity": "Q12345", "subject": "Q67890"})
+```
+
+Example templates in `data/templates/`: shrine, city, mountain, and more.
 
 ## Usage
 

--- a/data/templates/city.wikitext
+++ b/data/templates/city.wikitext
@@ -1,0 +1,10 @@
+---
+title: City
+description: >
+  Basic city article: location statement + class membership.
+variables:
+  country: Q-item   # Country the city is in
+  class: Q-item     # e.g. Q515 (city), Q1549591 (big city)
+---
+
+{{Z26570 | $subject | $class | $country}}

--- a/data/templates/mountain.wikitext
+++ b/data/templates/mountain.wikitext
@@ -1,0 +1,12 @@
+---
+title: Mountain (superlative)
+description: >
+  Mountain article using superlative definition.
+  Example: "Mount Everest is the tallest mountain in Asia."
+variables:
+  adjective: Q-item   # e.g. Q1151067 (tall)
+  class: Q-item        # e.g. Q8502 (mountain)
+  location: Q-item     # e.g. Q48 (Asia)
+---
+
+{{Z27243 | $subject | $adjective | $class | $location}}

--- a/data/templates/shinto_shrine.wikitext
+++ b/data/templates/shinto_shrine.wikitext
@@ -1,0 +1,13 @@
+---
+title: Shinto Shrine
+description: >
+  Creates an article for a Shinto shrine with location and deity sentences.
+  Equivalent to create_rich_onepass.py but in template form.
+variables:
+  deity: Q-item    # Wikidata QID for the shrine's deity
+---
+
+# Lead section: location + deity
+
+{{Z26570 | $subject | Q845945 | Q17}}
+{{Z28016 | $deity | Q11591100 | $subject}}

--- a/data/templates/shinto_shrine_3frag.wikitext
+++ b/data/templates/shinto_shrine_3frag.wikitext
@@ -1,0 +1,15 @@
+---
+title: Shinto Shrine (3-fragment)
+description: >
+  Three-fragment version with administrative territory.
+  Equivalent to create_rich_threepass.py.
+variables:
+  deity: Q-item    # Wikidata QID for the shrine's deity
+  admin: Q-item    # Administrative territory (prefecture/city)
+---
+
+# Lead section
+
+{{Z26570 | $subject | Q845945 | Q17}}
+{{Z28016 | $deity | Q11591100 | $subject}}
+{{Z26570 | $subject | Q845945 | $admin}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31.0
 python-dotenv>=1.0.0
+pyyaml>=6.0

--- a/tests/test_wikitext_parser.py
+++ b/tests/test_wikitext_parser.py
@@ -1,0 +1,487 @@
+"""Tests for the wikitext template parser."""
+
+import json
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from wikitext_parser import (
+    z6, z9s, z6091, z18, z7_call,
+    resolve_value, parse_frontmatter, parse_template_calls,
+    build_func_call, compile_template, parse_template,
+    wrap_as_fragment, build_clipboard_item, FUNCTION_REGISTRY,
+)
+
+
+# ============================================================
+# Z-object helper tests
+# ============================================================
+
+class TestZObjectHelpers:
+    def test_z6_string(self):
+        assert z6("hello") == {"Z1K1": "Z6", "Z6K1": "hello"}
+
+    def test_z9s_reference(self):
+        assert z9s("Z7") == {"Z1K1": "Z9", "Z9K1": "Z7"}
+
+    def test_z6091_qid(self):
+        result = z6091("Q42")
+        assert result["Z1K1"] == z9s("Z6091")
+        assert result["Z6091K1"] == z6("Q42")
+
+    def test_z18_arg_ref(self):
+        result = z18("Z825K1")
+        assert result["Z1K1"] == z9s("Z18")
+        assert result["Z18K1"] == z6("Z825K1")
+
+    def test_z7_call(self):
+        result = z7_call("Z26570", {"Z26570K1": z6("test")})
+        assert result["Z1K1"] == z9s("Z7")
+        assert result["Z7K1"] == z9s("Z26570")
+        assert result["Z26570K1"] == z6("test")
+
+
+# ============================================================
+# Value resolution tests
+# ============================================================
+
+class TestResolveValue:
+    def test_subject_ref(self):
+        result = resolve_value("$subject")
+        assert result == z18("Z825K1")
+
+    def test_lang_ref(self):
+        result = resolve_value("$lang")
+        assert result == z18("Z825K2")
+
+    def test_qid(self):
+        result = resolve_value("Q845945")
+        assert result == z6091("Q845945")
+
+    def test_variable_resolves_to_qid(self):
+        result = resolve_value("$deity", {"deity": "Q12345"})
+        assert result == z6091("Q12345")
+
+    def test_undefined_variable_raises(self):
+        with pytest.raises(ValueError, match="Undefined variable"):
+            resolve_value("$unknown")
+
+    def test_z_reference(self):
+        result = resolve_value("Z41")
+        assert result == z9s("Z41")
+
+    def test_boolean_true(self):
+        result = resolve_value("true")
+        assert result == z9s("Z41")
+
+    def test_boolean_false(self):
+        result = resolve_value("false")
+        assert result == z9s("Z42")
+
+    def test_plain_string(self):
+        result = resolve_value("hello world")
+        assert result == z6("hello world")
+
+    def test_whitespace_stripped(self):
+        result = resolve_value("  Q42  ")
+        assert result == z6091("Q42")
+
+
+# ============================================================
+# Frontmatter parsing tests
+# ============================================================
+
+class TestParseFrontmatter:
+    def test_with_frontmatter(self):
+        text = """---
+title: Test
+variables:
+  deity: Q-item
+---
+{{Z26570 | $subject | Q845945 | Q17}}"""
+        meta, body = parse_frontmatter(text)
+        assert meta["title"] == "Test"
+        assert "deity" in meta["variables"]
+        assert "{{Z26570" in body
+
+    def test_without_frontmatter(self):
+        text = "{{Z26570 | $subject | Q845945 | Q17}}"
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert "{{Z26570" in body
+
+    def test_empty_frontmatter(self):
+        text = """---
+---
+{{Z26570 | $subject | Q845945 | Q17}}"""
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert "{{Z26570" in body
+
+
+# ============================================================
+# Template call parsing tests
+# ============================================================
+
+class TestParseTemplateCalls:
+    def test_single_call(self):
+        body = "{{Z26570 | $subject | Q845945 | Q17}}"
+        result = parse_template_calls(body)
+        assert len(result) == 1
+        assert result[0]["func_id"] == "Z26570"
+        assert result[0]["args"] == ["$subject", "Q845945", "Q17"]
+
+    def test_multiple_calls(self):
+        body = """{{Z26570 | $subject | Q845945 | Q17}}
+{{Z28016 | $deity | Q11591100 | $subject}}"""
+        result = parse_template_calls(body)
+        assert len(result) == 2
+        assert result[0]["func_id"] == "Z26570"
+        assert result[1]["func_id"] == "Z28016"
+
+    def test_named_args(self):
+        body = "{{Z26570 | entity=$subject | class=Q845945 | location=Q17}}"
+        result = parse_template_calls(body)
+        assert result[0]["named_args"]["entity"] == "$subject"
+        assert result[0]["named_args"]["class"] == "Q845945"
+        assert result[0]["named_args"]["location"] == "Q17"
+        assert result[0]["args"] == []
+
+    def test_mixed_args(self):
+        body = "{{Z26570 | $subject | class=Q845945 | Q17}}"
+        result = parse_template_calls(body)
+        assert result[0]["args"] == ["$subject", "Q17"]
+        assert result[0]["named_args"]["class"] == "Q845945"
+
+    def test_comments_ignored(self):
+        body = """# This is a comment
+{{Z26570 | $subject | Q845945 | Q17}}
+# Another comment"""
+        result = parse_template_calls(body)
+        assert len(result) == 1
+
+    def test_line_numbers(self):
+        body = """# Comment
+{{Z26570 | $subject | Q845945 | Q17}}
+
+{{Z28016 | $deity | Q11591100 | $subject}}"""
+        result = parse_template_calls(body)
+        assert result[0]["line"] == 2
+        assert result[1]["line"] == 4
+
+
+# ============================================================
+# Function call building tests
+# ============================================================
+
+class TestBuildFuncCall:
+    def test_z26570_positional(self):
+        frag = {
+            "func_id": "Z26570",
+            "args": ["$subject", "Q845945", "Q17"],
+            "named_args": {},
+        }
+        call, ret_type = build_func_call(frag)
+        assert ret_type == "Z11"
+        assert call["Z7K1"] == z9s("Z26570")
+        # K1 = entity = $subject -> Z825K1
+        assert call["Z26570K1"] == z18("Z825K1")
+        # K2 = class = Q845945
+        assert call["Z26570K2"] == z6091("Q845945")
+        # K3 = location = Q17
+        assert call["Z26570K3"] == z6091("Q17")
+        # K4 = language = auto-filled
+        assert call["Z26570K4"] == z18("Z825K2")
+
+    def test_z28016_with_variable(self):
+        frag = {
+            "func_id": "Z28016",
+            "args": ["$deity", "Q11591100", "$subject"],
+            "named_args": {},
+        }
+        call, ret_type = build_func_call(frag, {"deity": "Q99999"})
+        assert ret_type == "Z11"
+        # K1 = subject = $deity -> Q99999
+        assert call["Z28016K1"] == z6091("Q99999")
+        # K2 = role = Q11591100
+        assert call["Z28016K2"] == z6091("Q11591100")
+        # K3 = dependency = $subject -> Z825K1
+        assert call["Z28016K3"] == z18("Z825K1")
+        # K4 = language = auto
+        assert call["Z28016K4"] == z18("Z825K2")
+
+    def test_z26039_returns_z6(self):
+        frag = {
+            "func_id": "Z26039",
+            "args": ["$subject", "Q515"],
+            "named_args": {},
+        }
+        call, ret_type = build_func_call(frag)
+        assert ret_type == "Z6"
+
+    def test_named_args(self):
+        frag = {
+            "func_id": "Z26570",
+            "args": [],
+            "named_args": {
+                "entity": "$subject",
+                "class": "Q845945",
+                "location": "Q17",
+            },
+        }
+        call, _ = build_func_call(frag)
+        assert call["Z26570K1"] == z18("Z825K1")
+        assert call["Z26570K2"] == z6091("Q845945")
+        assert call["Z26570K3"] == z6091("Q17")
+
+    def test_unknown_function(self):
+        frag = {
+            "func_id": "Z99999",
+            "args": ["Q42", "Q17"],
+            "named_args": {},
+        }
+        call, ret_type = build_func_call(frag)
+        assert call["Z7K1"] == z9s("Z99999")
+        assert "Z99999K1" in call
+        assert "Z99999K2" in call
+
+    def test_missing_args_raises(self):
+        frag = {
+            "func_id": "Z26570",
+            "args": ["$subject"],  # Missing class and location
+            "named_args": {},
+        }
+        with pytest.raises(ValueError, match="Not enough arguments"):
+            build_func_call(frag)
+
+    def test_unknown_named_param_raises(self):
+        frag = {
+            "func_id": "Z26570",
+            "args": [],
+            "named_args": {"nonexistent": "Q42"},
+        }
+        with pytest.raises(ValueError, match="Unknown parameter"):
+            build_func_call(frag)
+
+
+# ============================================================
+# Wrapping tests
+# ============================================================
+
+class TestWrapAsFragment:
+    def test_z11_wraps_with_z29749(self):
+        inner = z7_call("Z28016", {})
+        result = wrap_as_fragment("Z28016", inner, "Z11")
+        assert result["Z7K1"] == z9s("Z29749")
+        assert result["Z29749K1"] == inner
+        assert result["Z29749K2"] == z18("Z825K2")
+
+    def test_z6_wraps_with_z27868(self):
+        inner = z7_call("Z26039", {})
+        result = wrap_as_fragment("Z26039", inner, "Z6")
+        assert result["Z7K1"] == z9s("Z27868")
+        assert result["Z27868K1"] == inner
+
+    def test_z89_no_wrap(self):
+        inner = z7_call("Z29822", {})
+        result = wrap_as_fragment("Z29822", inner, "Z89")
+        assert result is inner
+
+
+# ============================================================
+# Clipboard item envelope tests
+# ============================================================
+
+class TestBuildClipboardItem:
+    def test_envelope_structure(self):
+        value = {"test": True}
+        item = build_clipboard_item(value, index=0, origin_qid="Q12345")
+        assert item["itemId"] == "Q12345.1#1"
+        assert item["originKey"] == "Q12345.1"
+        assert item["originSlotType"] == "Z89"
+        assert item["value"] == value
+        assert item["objectType"] == "Z7"
+        assert item["resolvingType"] == "Z89"
+
+    def test_index_increments(self):
+        item0 = build_clipboard_item({}, index=0)
+        item1 = build_clipboard_item({}, index=1)
+        assert item0["itemId"].endswith(".1#1")
+        assert item1["itemId"].endswith(".2#1")
+
+
+# ============================================================
+# Full compile_template integration tests
+# ============================================================
+
+class TestCompileTemplate:
+    def test_shrine_template(self):
+        template = """---
+title: Shinto Shrine
+variables:
+  deity: Q-item
+---
+{{Z26570 | $subject | Q845945 | Q17}}
+{{Z28016 | $deity | Q11591100 | $subject}}"""
+
+        result = compile_template(template, {"deity": "Q99999", "subject": "Q12345"})
+        assert len(result) == 2
+
+        # First fragment: location
+        frag0 = result[0]
+        assert frag0["resolvingType"] == "Z89"
+        assert frag0["itemId"] == "Q12345.1#1"
+        # Should be wrapped with Z29749 (Z11 -> Z89)
+        assert frag0["value"]["Z7K1"] == z9s("Z29749")
+
+        # Second fragment: deity
+        frag1 = result[1]
+        assert frag1["itemId"] == "Q12345.2#1"
+        assert frag1["value"]["Z7K1"] == z9s("Z29749")
+
+    def test_no_frontmatter(self):
+        template = "{{Z26570 | $subject | Q845945 | Q17}}"
+        result = compile_template(template)
+        assert len(result) == 1
+
+    def test_three_fragment_shrine(self):
+        template = """{{Z26570 | $subject | Q845945 | Q17}}
+{{Z28016 | $deity | Q11591100 | $subject}}
+{{Z26570 | $subject | Q845945 | $admin}}"""
+
+        result = compile_template(template, {
+            "deity": "Q111",
+            "admin": "Q222",
+        })
+        assert len(result) == 3
+
+    def test_z6_returning_function_wraps_z27868(self):
+        template = "{{Z26039 | $subject | Q515}}"
+        result = compile_template(template)
+        assert result[0]["value"]["Z7K1"] == z9s("Z27868")
+
+
+# ============================================================
+# Comparison with existing hardcoded templates
+# ============================================================
+
+class TestMatchesExistingOutput:
+    """Verify parser output matches the hardcoded CLIPBOARD_TEMPLATE from create_rich_onepass.py."""
+
+    def test_deity_fragment_structure(self):
+        """The deity fragment should match the Z28016 call structure."""
+        template = "{{Z28016 | $deity | Q11591100 | $subject}}"
+        result = compile_template(template, {"deity": "Q99999"})
+        frag = result[0]["value"]
+
+        # Outer: Z29749 (monolingual text -> HTML with auto-langcode)
+        assert frag["Z7K1"]["Z9K1"] == "Z29749"
+
+        # Inner: Z28016 function call
+        inner = frag["Z29749K1"]
+        assert inner["Z7K1"]["Z9K1"] == "Z28016"
+
+        # Z28016K1 = deity QID
+        assert inner["Z28016K1"]["Z6091K1"]["Z6K1"] == "Q99999"
+        # Z28016K2 = role (Q11591100)
+        assert inner["Z28016K2"]["Z6091K1"]["Z6K1"] == "Q11591100"
+        # Z28016K3 = dependency ($subject -> Z825K1)
+        assert inner["Z28016K3"]["Z18K1"]["Z6K1"] == "Z825K1"
+        # Z28016K4 = language (auto -> Z825K2)
+        assert inner["Z28016K4"]["Z18K1"]["Z6K1"] == "Z825K2"
+
+        # Z29749K2 = language ref
+        assert frag["Z29749K2"]["Z18K1"]["Z6K1"] == "Z825K2"
+
+    def test_location_fragment_structure(self):
+        """The location fragment uses Z26570 wrapped in Z29749."""
+        template = "{{Z26570 | $subject | Q845945 | Q17}}"
+        result = compile_template(template)
+        frag = result[0]["value"]
+
+        # Outer: Z29749
+        assert frag["Z7K1"]["Z9K1"] == "Z29749"
+
+        # Inner: Z26570
+        inner = frag["Z29749K1"]
+        assert inner["Z7K1"]["Z9K1"] == "Z26570"
+
+        # K1 = entity ($subject -> Z825K1)
+        assert inner["Z26570K1"]["Z18K1"]["Z6K1"] == "Z825K1"
+        # K2 = class (Q845945)
+        assert inner["Z26570K2"]["Z6091K1"]["Z6K1"] == "Q845945"
+        # K3 = location (Q17)
+        assert inner["Z26570K3"]["Z6091K1"]["Z6K1"] == "Q17"
+        # K4 = language (auto Z825K2)
+        assert inner["Z26570K4"]["Z18K1"]["Z6K1"] == "Z825K2"
+
+
+# ============================================================
+# Template file loading test
+# ============================================================
+
+class TestTemplateFiles:
+    """Test that the example template files parse correctly."""
+
+    TEMPLATES_DIR = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "data", "templates"
+    )
+
+    def test_shinto_shrine_template(self):
+        path = os.path.join(self.TEMPLATES_DIR, "shinto_shrine.wikitext")
+        with open(path) as f:
+            text = f.read()
+        parsed = parse_template(text)
+        assert parsed["metadata"]["title"] == "Shinto Shrine"
+        assert len(parsed["fragments"]) == 2
+
+    def test_shinto_shrine_3frag_template(self):
+        path = os.path.join(self.TEMPLATES_DIR, "shinto_shrine_3frag.wikitext")
+        with open(path) as f:
+            text = f.read()
+        parsed = parse_template(text)
+        assert len(parsed["fragments"]) == 3
+
+    def test_city_template(self):
+        path = os.path.join(self.TEMPLATES_DIR, "city.wikitext")
+        with open(path) as f:
+            text = f.read()
+        result = compile_template(text, {
+            "country": "Q30",
+            "class": "Q515",
+            "subject": "Q60",
+        })
+        assert len(result) == 1
+
+    def test_mountain_template(self):
+        path = os.path.join(self.TEMPLATES_DIR, "mountain.wikitext")
+        with open(path) as f:
+            text = f.read()
+        result = compile_template(text, {
+            "adjective": "Q1151067",
+            "class": "Q8502",
+            "location": "Q48",
+            "subject": "Q513",
+        })
+        assert len(result) == 1
+        # Z27243 returns Z11, should be wrapped with Z29749
+        assert result[0]["value"]["Z7K1"]["Z9K1"] == "Z29749"
+
+
+class TestFunctionRegistry:
+    def test_all_registered_functions_have_params(self):
+        for fid, info in FUNCTION_REGISTRY.items():
+            assert "params" in info, f"{fid} missing params"
+            assert "returns" in info, f"{fid} missing returns"
+            assert "name" in info, f"{fid} missing name"
+            assert len(info["params"]) > 0, f"{fid} has no params"
+
+    def test_all_functions_have_language_param(self):
+        """Most sentence generators take a language param."""
+        for fid, info in FUNCTION_REGISTRY.items():
+            lang_params = [p for p in info["params"] if p["type"] == "language"]
+            # Every function should have exactly one language param
+            assert len(lang_params) == 1, f"{fid} should have exactly 1 language param"

--- a/todo.md
+++ b/todo.md
@@ -10,12 +10,15 @@
 
 ## In Progress
 
-- [ ] **Markdown-to-article system**: Build a system that translates a simple markdown file
-  into Abstract Wikipedia article content using Wikifunctions Z-objects.
-  - The markdown would describe an article in human-readable terms
-  - The system converts each section/sentence into the appropriate nested Z-object JSON
-  - Fragments are injected into the editor clipboard and published via Playwright
-  - This decouples "what the article says" from the complex Z-object nesting format
+- [x] **Wiki text template parser** (`wikitext_parser.py`): MediaWiki-inspired template syntax
+  that converts human-readable `{{Z26570 | $subject | Q845945 | Q17}}` into clipboard JSON.
+  - 13 sentence generators in the function registry
+  - Auto-wrapping (Z11 -> Z29749, Z6 -> Z27868, Z89 -> passthrough)
+  - YAML frontmatter for metadata and variable declarations
+  - Example templates: shrine, city, mountain in `data/templates/`
+  - 48 unit tests in `tests/test_wikitext_parser.py`
+- [ ] **Chrome extension**: Package the template parser + clipboard injection as a
+  browser extension anyone can use to create Abstract Wikipedia pages
 
 ## Next Steps
 

--- a/wikitext_parser.py
+++ b/wikitext_parser.py
@@ -1,0 +1,611 @@
+"""Wiki text template parser for Abstract Wikipedia pages.
+
+Converts a human-readable template syntax into the nested Z-object clipboard
+JSON that Abstract Wikipedia's visual editor expects. Templates use a
+MediaWiki-inspired syntax:
+
+    {{Z26570 | $subject | Q845945 | Q17}}
+
+Each {{...}} block becomes one clipboard fragment. The parser handles:
+- Z-function calls with positional or named arguments
+- $subject / $lang as implicit article entity/language references
+- Q-items automatically wrapped as Wikidata item references (Z6091)
+- $variables filled in at render time
+- Auto-wrapping: Z11-returning functions get Z29749, Z6-returning get Z27868
+
+Template format:
+    ---
+    title: My Template
+    variables:
+      deity: Q-item
+    ---
+    {{Z26570 | $subject | Q845945 | Q17}}
+    {{Z28016 | $deity | Q11591100 | $subject}}
+
+Usage:
+    from wikitext_parser import compile_template
+
+    clipboard = compile_template(template_text, {
+        "deity": "Q12345",
+        "subject": "Q67890",
+    })
+"""
+
+import re
+import copy
+import yaml
+
+
+# ============================================================
+# Z-object helpers (same patterns as create_rich_threepass.py)
+# ============================================================
+
+def z9(zid):
+    """Build a Z9 reference: {"Z1K1": {"Z1K1": "Z9", "Z9K1": "Z9"}, "Z9K1": zid}."""
+    return {"Z1K1": {"Z1K1": "Z9", "Z9K1": "Z9"}, "Z9K1": zid}
+
+
+def z9s(zid):
+    """Short Z9 reference used in clipboard format."""
+    return {"Z1K1": "Z9", "Z9K1": zid}
+
+
+def z6(value):
+    """Build a Z6 string literal."""
+    return {"Z1K1": "Z6", "Z6K1": value}
+
+
+def z6091(qid):
+    """Build a Wikidata item reference (Z6091) wrapping a QID string."""
+    return {
+        "Z1K1": z9s("Z6091"),
+        "Z6091K1": z6(qid),
+    }
+
+
+def z18(arg_key):
+    """Build an argument reference (Z18) for keys like Z825K1, Z825K2."""
+    return {
+        "Z1K1": z9s("Z18"),
+        "Z18K1": z6(arg_key),
+    }
+
+
+def z7_call(func_id, args_dict):
+    """Build a Z7 function call with named arguments.
+
+    func_id: e.g. "Z26570"
+    args_dict: e.g. {"Z26570K1": <z-obj>, "Z26570K2": <z-obj>}
+    """
+    result = {
+        "Z1K1": z9s("Z7"),
+        "Z7K1": z9s(func_id),
+    }
+    result.update(args_dict)
+    return result
+
+
+# ============================================================
+# Function registry: maps Z-function IDs to parameter metadata
+# ============================================================
+
+# Each entry: {
+#   "params": [{"key": "K1", "name": "human name", "type": "Z6091|Z60|Z18|..."}],
+#   "returns": "Z11" or "Z6" or "Z89",
+# }
+# The "type" field indicates what kind of value the parameter typically takes.
+# This is used for auto-wrapping arguments.
+
+FUNCTION_REGISTRY = {
+    "Z26570": {
+        "name": "State location using entity and class",
+        "example": "Seoul is a city in South Korea.",
+        "params": [
+            {"key": "K1", "name": "entity", "type": "entity_ref"},
+            {"key": "K2", "name": "class", "type": "Q-item"},
+            {"key": "K3", "name": "location", "type": "Q-item"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z28016": {
+        "name": "defining role sentence",
+        "example": "Paris is the capital of France.",
+        "params": [
+            {"key": "K1", "name": "subject", "type": "Q-item"},
+            {"key": "K2", "name": "role", "type": "Q-item"},
+            {"key": "K3", "name": "dependency", "type": "entity_ref"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z26039": {
+        "name": "Article-less instantiating fragment",
+        "example": "Nairobi is a city.",
+        "params": [
+            {"key": "K1", "name": "entity", "type": "entity_ref"},
+            {"key": "K2", "name": "class", "type": "Q-item"},
+            {"key": "K3", "name": "language", "type": "language"},
+        ],
+        "returns": "Z6",
+    },
+    "Z26095": {
+        "name": "Article-ful instantiating fragment",
+        "example": "An antelope is a mammal.",
+        "params": [
+            {"key": "K1", "name": "class", "type": "Q-item"},
+            {"key": "K2", "name": "super-class", "type": "Q-item"},
+            {"key": "K3", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z26627": {
+        "name": "Classifying a class of nouns",
+        "example": "Antelopes are mammals.",
+        "params": [
+            {"key": "K1", "name": "class", "type": "Q-item"},
+            {"key": "K2", "name": "class2", "type": "Q-item"},
+            {"key": "K3", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z29591": {
+        "name": "describing entity with adjective / class",
+        "example": "Venus is a rocky planet.",
+        "params": [
+            {"key": "K1", "name": "entity", "type": "entity_ref"},
+            {"key": "K2", "name": "adjective", "type": "Q-item"},
+            {"key": "K3", "name": "class", "type": "Q-item"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z27173": {
+        "name": "Describe the class of a class",
+        "example": "Ice is frozen water.",
+        "params": [
+            {"key": "K1", "name": "class_described", "type": "Q-item"},
+            {"key": "K2", "name": "adjective", "type": "Q-item"},
+            {"key": "K3", "name": "class_describing", "type": "Q-item"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z6",
+    },
+    "Z29743": {
+        "name": "description of class with adjective and superclass",
+        "example": "A sheep is a domesticated animal.",
+        "params": [
+            {"key": "K1", "name": "described_class", "type": "Q-item"},
+            {"key": "K2", "name": "adjective", "type": "Q-item"},
+            {"key": "K3", "name": "superclass", "type": "Q-item"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z27243": {
+        "name": "Superlative definition",
+        "example": "Mount Everest is the tallest mountain in Asia.",
+        "params": [
+            {"key": "K1", "name": "entity", "type": "entity_ref"},
+            {"key": "K2", "name": "adjective", "type": "Q-item"},
+            {"key": "K3", "name": "class", "type": "Q-item"},
+            {"key": "K4", "name": "location", "type": "Q-item"},
+            {"key": "K5", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z26955": {
+        "name": "SPO sentence, S without and O with article",
+        "example": "English is a language.",
+        "params": [
+            {"key": "K1", "name": "predicate", "type": "Q-item"},
+            {"key": "K2", "name": "subject_item", "type": "Q-item"},
+            {"key": "K3", "name": "object_item", "type": "Q-item"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z6",
+    },
+    "Z28803": {
+        "name": "short description for album",
+        "example": "1968 album by The Beatles",
+        "params": [
+            {"key": "K1", "name": "album", "type": "Q-item"},
+            {"key": "K2", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z30000": {
+        "name": "Sunset sentence for location on date",
+        "example": "The sun set in Tokyo at 5:23 PM on March 28.",
+        "params": [
+            {"key": "K1", "name": "location", "type": "Q-item"},
+            {"key": "K2", "name": "date_of_sunset", "type": "date"},
+            {"key": "K3", "name": "todays_date", "type": "date"},
+            {"key": "K4", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    "Z31405": {
+        "name": "Sentence that something begins",
+        "example": "The beginning of X",
+        "params": [
+            {"key": "K1", "name": "subject", "type": "Q-item"},
+            {"key": "K2", "name": "language", "type": "language"},
+        ],
+        "returns": "Z11",
+    },
+    # Structural / rendering functions (return Z89 directly)
+    "Z29822": {
+        "name": "ArticlePlaceholder render article",
+        "example": "Full auto-generated article from QID",
+        "params": [
+            {"key": "K1", "name": "display_language", "type": "language"},
+            {"key": "K2", "name": "item", "type": "Q-item"},
+            {"key": "K3", "name": "include_empty", "type": "boolean"},
+        ],
+        "returns": "Z89",
+    },
+}
+
+# Lookup by parameter name -> key for each function
+_PARAM_NAME_INDEX = {}
+for _fid, _finfo in FUNCTION_REGISTRY.items():
+    _PARAM_NAME_INDEX[_fid] = {}
+    for _p in _finfo["params"]:
+        _PARAM_NAME_INDEX[_fid][_p["name"]] = _p
+
+
+# ============================================================
+# Argument value resolution
+# ============================================================
+
+# Special variables that map to argument references (Z18)
+IMPLICIT_REFS = {
+    "$subject": "Z825K1",   # article entity
+    "$lang": "Z825K2",      # language
+}
+
+
+def resolve_value(raw_value, variables=None):
+    """Convert a raw template value into a Z-object.
+
+    Resolution rules:
+    - "$subject" / "$lang" -> Z18 argument reference
+    - "$varname" -> look up in variables dict, then treat result as a value
+    - "Q..." (Wikidata QID) -> Z6091 Wikidata item reference
+    - "Z..." that looks like a Z-ID -> Z9 reference
+    - Anything else -> Z6 string literal
+    """
+    variables = variables or {}
+    raw_value = raw_value.strip()
+
+    # Implicit argument references
+    if raw_value in IMPLICIT_REFS:
+        return z18(IMPLICIT_REFS[raw_value])
+
+    # Template variables ($deity, $admin, etc.)
+    if raw_value.startswith("$"):
+        var_name = raw_value[1:]
+        if var_name not in variables:
+            raise ValueError(f"Undefined variable: {raw_value}")
+        resolved = variables[var_name]
+        # Recurse: the resolved value might be a QID, Z-ID, etc.
+        return resolve_value(resolved, variables)
+
+    # Wikidata QID (Q followed by digits)
+    if re.match(r'^Q\d+$', raw_value):
+        return z6091(raw_value)
+
+    # Z-object reference (Z followed by digits, no K suffix)
+    if re.match(r'^Z\d+$', raw_value):
+        return z9s(raw_value)
+
+    # Boolean values for Abstract Wikipedia
+    if raw_value.lower() in ("true", "yes"):
+        return z9s("Z41")  # Z41 = true
+    if raw_value.lower() in ("false", "no"):
+        return z9s("Z42")  # Z42 = false
+
+    # Plain string
+    return z6(raw_value)
+
+
+# ============================================================
+# Wrapping: convert function output to clipboard-ready Z89
+# ============================================================
+
+def wrap_as_fragment(func_id, func_call, return_type):
+    """Wrap a function call in the appropriate outer layers to produce Z89.
+
+    The clipboard requires Z89 (HTML fragment) items. Different wrapping
+    strategies depending on what the inner function returns:
+
+    - Z11 (monolingual text) -> Z29749(func_call, Z825K2)
+      Wraps monolingual text into HTML fragment with auto language code.
+
+    - Z6 (string) -> Z27868(func_call)
+      Converts plain string to HTML fragment.
+
+    - Z89 (already HTML) -> no wrapping needed, return as-is.
+    """
+    if return_type == "Z11":
+        # Z29749: monolingual text as HTML fragment w/ auto-langcode
+        return z7_call("Z29749", {
+            "Z29749K1": func_call,
+            "Z29749K2": z18("Z825K2"),
+        })
+    elif return_type == "Z6":
+        # Z27868: string to HTML fragment
+        return z7_call("Z27868", {
+            "Z27868K1": func_call,
+        })
+    elif return_type == "Z89":
+        return func_call
+    else:
+        # Unknown return type — try Z29749 as a reasonable default
+        return z7_call("Z29749", {
+            "Z29749K1": func_call,
+            "Z29749K2": z18("Z825K2"),
+        })
+
+
+# ============================================================
+# Template parsing
+# ============================================================
+
+def parse_frontmatter(text):
+    """Split template into YAML frontmatter and body.
+
+    Returns (metadata_dict, body_string).
+    """
+    text = text.strip()
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            frontmatter_str = parts[1].strip()
+            body = parts[2].strip()
+            if frontmatter_str:
+                metadata = yaml.safe_load(frontmatter_str)
+            else:
+                metadata = {}
+            return metadata or {}, body
+    return {}, text
+
+
+def parse_template_calls(body):
+    """Extract all {{...}} template calls from the body text.
+
+    Returns a list of dicts:
+        {"func_id": "Z26570", "args": [...], "named_args": {...}, "line": N}
+
+    Supports both positional and named arguments:
+        {{Z26570 | $subject | Q845945 | Q17}}
+        {{Z26570 | entity=$subject | class=Q845945 | location=Q17}}
+    """
+    fragments = []
+    # Match {{ ... }} allowing newlines inside
+    pattern = re.compile(r'\{\{(.+?)\}\}', re.DOTALL)
+
+    for match in pattern.finditer(body):
+        inner = match.group(1).strip()
+        # Calculate line number
+        line_num = body[:match.start()].count('\n') + 1
+
+        parts = [p.strip() for p in inner.split('|')]
+        if not parts:
+            continue
+
+        func_id = parts[0].strip()
+        positional_args = []
+        named_args = {}
+
+        for part in parts[1:]:
+            if '=' in part and not part.startswith('$'):
+                key, _, value = part.partition('=')
+                named_args[key.strip()] = value.strip()
+            else:
+                positional_args.append(part)
+
+        fragments.append({
+            "func_id": func_id,
+            "args": positional_args,
+            "named_args": named_args,
+            "line": line_num,
+        })
+
+    return fragments
+
+
+def build_func_call(fragment_def, variables=None):
+    """Build a Z7 function call from a parsed fragment definition.
+
+    Resolves positional and named arguments using the function registry.
+    Language parameters are auto-filled with $lang if not provided.
+    """
+    func_id = fragment_def["func_id"]
+    positional = fragment_def["args"]
+    named = fragment_def["named_args"]
+    variables = variables or {}
+
+    # Look up function in registry
+    if func_id not in FUNCTION_REGISTRY:
+        # Unknown function: build a best-effort call using positional args
+        args_dict = {}
+        for i, val in enumerate(positional):
+            key = f"{func_id}K{i + 1}"
+            args_dict[key] = resolve_value(val, variables)
+        return z7_call(func_id, args_dict), "Z11"  # assume Z11 by default
+
+    func_info = FUNCTION_REGISTRY[func_id]
+    params = func_info["params"]
+    args_dict = {}
+
+    # Resolve named arguments first
+    used_positions = set()
+    for param_name, raw_value in named.items():
+        # Find the parameter by name
+        if func_id in _PARAM_NAME_INDEX and param_name in _PARAM_NAME_INDEX[func_id]:
+            param = _PARAM_NAME_INDEX[func_id][param_name]
+            full_key = f"{func_id}{param['key']}"
+            args_dict[full_key] = resolve_value(raw_value, variables)
+            # Mark this position as used
+            idx = next(i for i, p in enumerate(params) if p["name"] == param_name)
+            used_positions.add(idx)
+        else:
+            raise ValueError(
+                f"Unknown parameter '{param_name}' for function {func_id}. "
+                f"Available: {[p['name'] for p in params]}"
+            )
+
+    # Fill positional arguments into remaining slots
+    pos_iter = iter(positional)
+    for i, param in enumerate(params):
+        if i in used_positions:
+            continue
+        full_key = f"{func_id}{param['key']}"
+        if full_key in args_dict:
+            continue
+
+        # Auto-fill language parameter if not provided
+        if param["type"] == "language":
+            if full_key not in args_dict:
+                args_dict[full_key] = z18("Z825K2")
+            continue
+
+        try:
+            raw_value = next(pos_iter)
+        except StopIteration:
+            raise ValueError(
+                f"Not enough arguments for {func_id} ({func_info['name']}). "
+                f"Missing: {param['name']} ({param['key']})"
+            )
+
+        args_dict[full_key] = resolve_value(raw_value, variables)
+
+    return z7_call(func_id, args_dict), func_info["returns"]
+
+
+def build_clipboard_item(fragment_value, index=0, origin_qid="Q0"):
+    """Wrap a Z89-producing value in the clipboard item envelope."""
+    return {
+        "itemId": f"{origin_qid}.{index + 1}#1",
+        "originKey": f"{origin_qid}.{index + 1}",
+        "originSlotType": "Z89",
+        "value": fragment_value,
+        "objectType": "Z7",
+        "resolvingType": "Z89",
+    }
+
+
+# ============================================================
+# Public API
+# ============================================================
+
+def parse_template(text):
+    """Parse a wikitext template into metadata and fragment definitions.
+
+    Returns:
+        {
+            "metadata": {...frontmatter...},
+            "fragments": [...parsed fragment defs...],
+        }
+    """
+    metadata, body = parse_frontmatter(text)
+    fragments = parse_template_calls(body)
+    return {
+        "metadata": metadata,
+        "fragments": fragments,
+    }
+
+
+def compile_template(text, variables=None):
+    """Compile a wikitext template into clipboard-ready JSON.
+
+    This is the main entry point. Takes a template string and variable
+    values, returns a list of clipboard items ready for injection.
+
+    Args:
+        text: Template string in wikitext format.
+        variables: Dict mapping variable names to values (e.g. {"deity": "Q12345"}).
+
+    Returns:
+        List of clipboard item dicts, ready for inject_clipboard().
+    """
+    variables = variables or {}
+    parsed = parse_template(text)
+
+    # Merge frontmatter defaults with provided variables
+    meta_vars = parsed["metadata"].get("variables", {})
+    # meta_vars defines expected variables; actual values come from `variables` arg
+
+    # Validate: warn about undefined variables
+    for var_name in meta_vars:
+        if var_name not in variables and var_name != "subject":
+            # Not an error — might be optional or have defaults later
+            pass
+
+    origin_qid = variables.get("subject", "Q0")
+    clipboard_items = []
+
+    for i, frag_def in enumerate(parsed["fragments"]):
+        func_call, return_type = build_func_call(frag_def, variables)
+        wrapped = wrap_as_fragment(frag_def["func_id"], func_call, return_type)
+        item = build_clipboard_item(wrapped, index=i, origin_qid=origin_qid)
+        clipboard_items.append(item)
+
+    return clipboard_items
+
+
+def template_from_file(filepath, variables=None):
+    """Load and compile a template from a file path."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        text = f.read()
+    return compile_template(text, variables)
+
+
+def list_functions():
+    """Return a formatted string listing all registered functions."""
+    lines = []
+    for fid, info in sorted(FUNCTION_REGISTRY.items()):
+        params_str = ", ".join(
+            f"{p['name']}: {p['type']}" for p in info["params"]
+        )
+        lines.append(f"  {fid}: {info['name']}")
+        lines.append(f"    Example: \"{info['example']}\"")
+        lines.append(f"    Args: ({params_str}) -> {info['returns']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import sys
+    import json
+
+    if len(sys.argv) < 2:
+        print("Wiki Text Template Parser for Abstract Wikipedia")
+        print("=" * 50)
+        print()
+        print("Usage:")
+        print("  python wikitext_parser.py <template.wikitext> [var=value ...]")
+        print("  python wikitext_parser.py --list-functions")
+        print()
+        print("Example:")
+        print("  python wikitext_parser.py data/templates/shinto_shrine.wikitext deity=Q12345")
+        print()
+        print("Available functions:")
+        print(list_functions())
+        sys.exit(0)
+
+    if sys.argv[1] == "--list-functions":
+        print(list_functions())
+        sys.exit(0)
+
+    filepath = sys.argv[1]
+    variables = {}
+    for arg in sys.argv[2:]:
+        if "=" in arg:
+            key, _, value = arg.partition("=")
+            variables[key] = value
+
+    result = template_from_file(filepath, variables)
+    print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary

- Adds `wikitext_parser.py`: a MediaWiki-inspired template syntax (`{{Z26570 | $subject | Q845945 | Q17}}`) that compiles to the nested Z-object clipboard JSON the Abstract Wikipedia editor expects
- 13 sentence generators in the function registry, auto-wrapping (Z11→Z29749, Z6→Z27868, Z89→passthrough), YAML frontmatter, variable substitution
- 4 example templates in `data/templates/` (shrine, shrine-3frag, city, mountain)
- 48 unit tests + CI workflow on push/PR
- Updated requirements.txt (added pyyaml), README.md, todo.md

## Test plan

- [x] All 48 pytest tests pass locally
- [ ] CI workflow runs on this PR
- [ ] Manual test: `python wikitext_parser.py data/templates/shinto_shrine.wikitext deity=Q12345` produces valid clipboard JSON
- [ ] Integration test: feed parser output into `inject_clipboard()` and verify article creation

https://claude.ai/code/session_01HQ4Lp6TJxtjfftLjKwgX8k